### PR TITLE
Fix issue where filepaths starting with ~ are not opened

### DIFF
--- a/Spoons/MenuHammer.spoon/MenuAction.lua
+++ b/Spoons/MenuHammer.spoon/MenuAction.lua
@@ -360,6 +360,14 @@ function MenuAction:openFile(filePath)
 
     assert(filePath, "No file path provided")
 
+    local firstChar = filePath:sub(1, 1)
+    
+    if firstChar == "~" then
+        local homePath = os.getenv("HOME")
+        local filePathWithoutTilde = filePath:sub(2)
+        filePath = homePath .. filePathWithoutTilde
+    end
+
     local quotedFilePath = '\\"' .. filePath .. '\\"'
 
     local commandString = '"sh -c \'open ' .. quotedFilePath .. '\'"'


### PR DESCRIPTION
Hey, love this repo! I noticed that the cons.act.openfile menu action wasn't actually opening filepaths starting with ~, because the `open` command was not treating ~ as an abbreviation for home. I fixed it :)