### PR TITLE
When asking for input from the user the focus changes to hammerspoon.

### DIFF
--- a/Spoons/MenuHammer.spoon/MenuAction.lua
+++ b/Spoons/MenuHammer.spoon/MenuAction.lua
@@ -209,6 +209,7 @@ function MenuAction:getUserInput(valueIdentifier, messageValue, informativeText,
     if default == nil then
         default = ""
     end
+    local cwin = hs.window.focusedWindow()
 
     hs.focus()
 
@@ -219,6 +220,10 @@ function MenuAction:getUserInput(valueIdentifier, messageValue, informativeText,
                                                         "Cancel")
 
     self.parentMenu.menuManager.storedValues[valueIdentifier] = {buttonValue, textValue}
+
+    if cwin then
+      cwin:focus()
+    end
 
     if buttonValue == "Cancel" then
         return false

--- a/Spoons/MenuHammer.spoon/MenuManager.lua
+++ b/Spoons/MenuHammer.spoon/MenuManager.lua
@@ -33,9 +33,12 @@ MenuManager.activeMenu = nil
 MenuManager.menuItems = {}
 MenuManager.storedValues = {}
 
+MenuManager.showMenuDelay = 0.0
 MenuManager.rootMenu = nil
 
 MenuManager.spoonPath = hs.spoons.scriptPath()
+
+MenuManager.menuCallback = nil
 
 -- Import the Menu class
 Menu = dofile(MenuManager.spoonPath .. "/Menu.lua")
@@ -224,7 +227,10 @@ end
 ----------------------------------------------------------------------------------------------------
 -- Close menus
 function MenuManager:closeMenu()
-
+    if MenuManager.menuCallback then
+         MenuManager.menuCallback:stop()
+         MenuManager.menuCallback  = nil
+    end
     print("Closing menus")
     -- Shut off the active menu
     if self.activeMenu ~= nil then
@@ -276,7 +282,14 @@ function MenuManager:openMenu(menuName)
     end
 
     -- Show the menu
-    self.canvas:show()
+    if MenuManager.showMenuDelay > 0 then
+      -- this should never be called when a callback is active...
+      assert(MenuManager.menuCallback == nil)
+      MenuManager.menuCallback = hs.timer.doAfter(MenuManager.showMenuDelay,
+        function () self.canvas:show() end)
+    else
+        self.canvas:show()
+    end
 end
 
 ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This creates a problem when using cons.act.userinput followed by cons.act.typetext

This patch returns the focus to the currently focused window (if one exists). 

For example, these actions ask for text that is inserted into the current window (along some other text). Currently this is received by hammerspoon instead (due to the hs.focus() call in userinput)

            {cons.cat.action, '', 't', "with ", {
                {cons.act.userinput, "rname", "name", "more text"},
                {cons.act.typetext, "WITH @@rname@@ as ("},
            }},
